### PR TITLE
fixed problem with accordion headers appearing again after minor html ch...

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -2014,7 +2014,8 @@ input[type="button"][disabled] {
 }
 
 .accordion_header {
-	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+	display: none;
+	/*font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 	font-size: 12px;
 	font-weight: bold;
 	margin: 1px 0 0 0;
@@ -2024,7 +2025,7 @@ input[type="button"][disabled] {
 	list-style: none outside none;
 	outline: 0 none;
 	cursor: pointer;
-	text-decoration: none;
+	text-decoration: none;*/
 }
 
 .accordion_header_open a:link, .accordion_header_open a:visited, .accordion_header_open a:hover, .accordion_header_open a:active { color: #212121; }
@@ -3037,8 +3038,6 @@ div.results_tn_icon_favs_link {
 	border-bottom: 1px solid #ddd;
 	overflow: hidden;
 }
-
-#details_accordion h3{display: none !important;}
 
 #details_accordion>h3.accordion_header_active {
 	font-size: 13px;


### PR DESCRIPTION
Noticed that the headings in the accordions on the item page had reappeared. Looks like CDM modified the HTML structure a bit which broke the CSS rule to hide this. So, I made the rule more generic.

![employees at women s wear counter brown s department store des plaines history](https://cloud.githubusercontent.com/assets/489933/2533782/a6eb255e-b568-11e3-9e06-27d3a5e5707e.png)
